### PR TITLE
bug: aws sqs md5 hash mismatch

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* BREAKING: Switched AWSServiceName tag to use ServiceId instead of ServiceName
+  ([#1572](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1572))
+
 ## 1.1.0-beta.3
 
 Released 2024-Jan-26

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSPropagatorPipelineHandler.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSPropagatorPipelineHandler.cs
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.Runtime.Internal;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Extensions.AWS.Trace;
+
+namespace OpenTelemetry.Instrumentation.AWS.Implementation;
+
+/// <summary>
+/// Uses <see cref="AWSXRayPropagator"/> to inject the current Activity Context and
+/// Baggage into the outgoing AWS SDK Request.
+/// <para />
+/// Must execute after the AWS SDK has marshalled (ie serialized)
+/// the outgoing request object so that it can work with the <see cref="IRequest"/>'s
+/// <see cref="IRequest.Headers"/>.
+/// </summary>
+internal class AWSPropagatorPipelineHandler : PipelineHandler
+{
+    private static readonly AWSXRayPropagator AwsPropagator = new();
+
+    private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
+    {
+        carrier[name] = value;
+    };
+
+    /// <summary>
+    /// Rely on the the <see cref="AWSTracingPipelineHandler.Activity"/> for retrieving the current
+    /// context.
+    /// </summary>
+    private readonly AWSTracingPipelineHandler tracingPipelineHandler;
+
+    public AWSPropagatorPipelineHandler(AWSTracingPipelineHandler tracingPipelineHandler)
+    {
+        this.tracingPipelineHandler = tracingPipelineHandler;
+    }
+
+    public override void InvokeSync(IExecutionContext executionContext)
+    {
+        this.ProcessBeginRequest(executionContext);
+
+        base.InvokeSync(executionContext);
+    }
+
+    public override async Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+    {
+        this.ProcessBeginRequest(executionContext);
+
+        return await base.InvokeAsync<T>(executionContext).ConfigureAwait(false);
+    }
+
+    private void ProcessBeginRequest(IExecutionContext executionContext)
+    {
+        if (this.tracingPipelineHandler.Activity == null)
+        {
+            return;
+        }
+
+        AwsPropagator.Inject(
+            new PropagationContext(this.tracingPipelineHandler.Activity.Context, Baggage.Current),
+            executionContext.RequestContext.Request.Headers,
+            Setter);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceHelper.cs
@@ -21,7 +21,7 @@ internal class AWSServiceHelper
     };
 
     internal static string GetAWSServiceName(IRequestContext requestContext)
-        => Utils.RemoveAmazonPrefixFromServiceName(requestContext.Request.ServiceName);
+        => Utils.RemoveAmazonPrefixFromServiceName(requestContext.ServiceMetaData.ServiceId);
 
     internal static string GetAWSOperationName(IRequestContext requestContext)
     {

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSServiceType.cs
@@ -7,9 +7,9 @@ namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
 internal class AWSServiceType
 {
-    internal const string DynamoDbService = "DynamoDBv2";
+    internal const string DynamoDbService = "DynamoDB";
     internal const string SQSService = "SQS";
-    internal const string SNSService = "SimpleNotificationService"; // SNS
+    internal const string SNSService = "SNS";
 
     internal static bool IsDynamoDbService(string service)
         => DynamoDbService.Equals(service, StringComparison.OrdinalIgnoreCase);

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -31,6 +31,6 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
             return;
         }
 
-        pipeline.AddHandlerBefore<RetryHandler>(new AWSTracingPipelineHandler(this.options));
+        pipeline.AddHandlerBefore<Marshaller>(new AWSTracingPipelineHandler(this.options));
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/AWSTracingPipelineCustomizer.cs
@@ -7,6 +7,10 @@ using Amazon.Runtime.Internal;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation;
 
+/// <summary>
+/// Wires <see cref="AWSTracingPipelineHandler"/> and <see cref="AWSPropagatorPipelineHandler"/>
+/// into the AWS <see cref="RuntimePipeline"/> so they can inject trace headers and wrap sdk calls in spans.
+/// </summary>
 internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
 {
     private readonly AWSClientInstrumentationOptions options;
@@ -31,6 +35,15 @@ internal class AWSTracingPipelineCustomizer : IRuntimePipelineCustomizer
             return;
         }
 
-        pipeline.AddHandlerBefore<Marshaller>(new AWSTracingPipelineHandler(this.options));
+        var tracingPipelineHandler = new AWSTracingPipelineHandler(this.options);
+        var propagatingPipelineHandler = new AWSPropagatorPipelineHandler(tracingPipelineHandler);
+
+        // AWSTracingPipelineHandler must execute early in the AWS SDK pipeline
+        // in order to manipulate outgoing requests objects before they are marshalled (ie serialized).
+        pipeline.AddHandlerBefore<Marshaller>(tracingPipelineHandler);
+
+        // AWSPropagatorPipelineHandler executes after the AWS SDK has marshalled (ie serialized)
+        // the outgoing request object so that it can work with the request's Headers
+        pipeline.AddHandlerBefore<RetryHandler>(propagatingPipelineHandler);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/Implementation/SqsRequestContextHelper.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Runtime;
-using Amazon.Runtime.Internal;
 using Amazon.SQS.Model;
 
 namespace OpenTelemetry.Instrumentation.AWS.Implementation;
@@ -18,9 +17,8 @@ internal class SqsRequestContextHelper
 
     internal static void AddAttributes(IRequestContext context, IReadOnlyDictionary<string, string> attributes)
     {
-        var parameters = context.Request?.ParameterCollection;
         var originalRequest = context.OriginalRequest as SendMessageRequest;
-        if (originalRequest?.MessageAttributes == null || parameters == null)
+        if (originalRequest?.MessageAttributes == null)
         {
             return;
         }
@@ -38,23 +36,9 @@ internal class SqsRequestContextHelper
             return;
         }
 
-        int nextAttributeIndex = attributesCount + 1;
         foreach (var param in attributes)
         {
-            AddAttribute(parameters, originalRequest, param.Key, param.Value, nextAttributeIndex);
-            nextAttributeIndex++;
+            originalRequest.MessageAttributes[param.Key] = new MessageAttributeValue { DataType = "String", StringValue = param.Value };
         }
-    }
-
-    private static void AddAttribute(ParameterCollection parameters, SendMessageRequest originalRequest, string name, string value, int attributeIndex)
-    {
-        var prefix = "MessageAttribute." + attributeIndex;
-        parameters.Add(prefix + ".Name", name);
-        parameters.Add(prefix + ".Value.DataType", "String");
-        parameters.Add(prefix + ".Value.StringValue", value);
-
-        // Add injected attributes to the original request as well.
-        // This dictionary must be in sync with parameters collection to pass through the MD5 hash matching check.
-        originalRequest.MessageAttributes.Add(name, new MessageAttributeValue { DataType = "String", StringValue = value });
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AWS/TracerProviderBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class TracerProviderBuilderExtensions
         configure?.Invoke(awsClientOptions);
 
         _ = new AWSClientsInstrumentation(awsClientOptions);
-        builder.AddSource("Amazon.AWS.AWSClientInstrumentation");
+        builder.AddSource(AWSTracingPipelineHandler.ActivitySourceName);
         return builder;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.2
+
+Released 2024-Feb-07
+
 ## 1.7.0-beta.1
 
 Released 2023-Dec-20

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.2
+
+Released 2024-Feb-07
+
 * Fix description for `http.server.request.duration` metric.
   ([#1538](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538))
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -7,6 +7,7 @@
 Released 2024-Feb-07
 
 * **Breaking Change**: Stop emitting `db.statement_type` attribute.
+  This attribute never was part of the [semantic convention](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md#call-level-attributes).
   ([#1559](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1559))
 
 ## 1.0.0-beta.9

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.10
+
+Released 2024-Feb-07
+
 * **Breaking Change**: Stop emitting `db.statement_type` attribute.
   ([#1559](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1559))
 

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc.15
+
+Released 2024-Feb-07
+
 * Fixed [GHSA-vh55-786g-wjwj](https://github.com/advisories/GHSA-vh55-786g-wjwj)
   by bumping the
   [System.Security.Cryptography.Xml](https://www.nuget.org/packages/System.Security.Cryptography.Xml)

--- a/src/OpenTelemetry.ResourceDetectors.AWS/AWSResourcesEventSource.cs
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/AWSResourcesEventSource.cs
@@ -24,12 +24,12 @@ internal sealed class AWSResourcesEventSource : EventSource
     [Event(1, Message = "Failed to extract resource attributes in '{0}'.", Level = EventLevel.Warning)]
     public void FailedToExtractResourceAttributes(string format, string exception)
     {
-        this.WriteEvent(3, format, exception);
+        this.WriteEvent(1, format, exception);
     }
 
     [Event(2, Message = "Failed to validate certificate in format: '{0}', error: '{1}'.", Level = EventLevel.Warning)]
     public void FailedToValidateCertificate(string format, string error)
     {
-        this.WriteEvent(4, format, error);
+        this.WriteEvent(2, format, error);
     }
 }

--- a/src/OpenTelemetry.ResourceDetectors.AWS/Http/ServerCertificateValidationProvider.cs
+++ b/src/OpenTelemetry.ResourceDetectors.AWS/Http/ServerCertificateValidationProvider.cs
@@ -84,24 +84,24 @@ internal class ServerCertificateValidationProvider
         {
             if ((errors | SslPolicyErrors.RemoteCertificateNotAvailable) == errors)
             {
-                AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Failed to validate certificate due to RemoteCertificateNotAvailable");
+                AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "SslPolicyError RemoteCertificateNotAvailable occurred");
             }
 
             if ((errors | SslPolicyErrors.RemoteCertificateNameMismatch) == errors)
             {
-                AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Failed to validate certificate due to RemoteCertificateNameMismatch");
+                AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "SslPolicyError RemoteCertificateNameMismatch occurred");
             }
         }
 
         if (chain == null)
         {
-            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Failed to validate certificate. Certificate chain is null.");
+            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Certificate chain is null.");
             return false;
         }
 
         if (cert == null)
         {
-            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Failed to validate certificate. Certificate is null.");
+            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), "Certificate is null.");
             return false;
         }
 
@@ -123,7 +123,7 @@ internal class ServerCertificateValidationProvider
                 }
             }
 
-            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), $"Failed to validate certificate due to {chainErrors}");
+            AWSResourcesEventSource.Log.FailedToValidateCertificate(nameof(ServerCertificateValidationProvider), chainErrors);
         }
 
         // check if at least one certificate in the chain is in our trust list

--- a/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.ResourceDetectors.Container/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-beta.6
+
+Released 2024-Feb-07
+
 * **Breaking** Changed target framework from .NET Standard 2.0
   to .NET 6.0. It drops support for .NET Framework.
   ([#1536](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1536))

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/Implementation/RequestContextHelperTests.cs
@@ -10,6 +10,8 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AWS.Implementation;
 using OpenTelemetry.Trace;
 using Xunit;
+using SNS = Amazon.SimpleNotificationService.Model;
+using SQS = Amazon.SQS.Model;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests.Implementation;
 
@@ -30,7 +32,7 @@ public class RequestContextHelperTests
     [InlineData(AWSServiceType.SNSService)]
     public void AddAttributes_ParametersCollectionSizeReachesLimit_TraceDataNotInjected(string serviceType)
     {
-        AmazonWebServiceRequest originalRequest = TestsHelper.CreateOriginalRequest(serviceType, 10);
+        var originalRequest = TestsHelper.CreateOriginalRequest(serviceType, 10);
         var parameters = new ParameterCollection();
         parameters.AddStringParameters(serviceType, originalRequest);
 
@@ -44,82 +46,82 @@ public class RequestContextHelperTests
         Assert.Equal(30, parameters.Count);
     }
 
-    [Theory]
-    [InlineData(AWSServiceType.SQSService)]
-    [InlineData(AWSServiceType.SNSService)]
-    public void AddAttributes_ParametersCollection_TraceDataInjected(string serviceType)
+    [Fact]
+    public void SQS_AddAttributes_MessageAttributes_TraceDataInjected()
     {
-        var expectedParameters = new List<KeyValuePair<string, string>>()
+        var expectedParameters = new List<KeyValuePair<string, string>>
         {
             new("traceparent", $"00-{TraceId}-{ParentId}-00"),
             new("tracestate", "trace-state"),
         };
 
-        AmazonWebServiceRequest originalRequest = TestsHelper.CreateOriginalRequest(serviceType, 0);
-        var parameters = new ParameterCollection();
+        var originalRequest = new SQS.SendMessageRequest();
 
-        var request = new TestRequest(parameters);
-        var context = new TestRequestContext(originalRequest, request);
+        var context = new TestRequestContext(originalRequest, new TestRequest());
 
-        var addAttributes = TestsHelper.CreateAddAttributesAction(serviceType, context);
-        addAttributes?.Invoke(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
+        SqsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
 
-        TestsHelper.AssertStringParameters(serviceType, expectedParameters, parameters);
+        TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
     }
 
-    [Theory]
-    [InlineData(AWSServiceType.SQSService)]
-    [InlineData(AWSServiceType.SNSService)]
-    public void AddAttributes_ParametersCollectionWithCustomParameter_TraceDataInjected(string serviceType)
+    [Fact]
+    public void SNS_AddAttributes_MessageAttributes_TraceDataInjected()
     {
-        var expectedParameters = new List<KeyValuePair<string, string>>()
+        var expectedParameters = new List<KeyValuePair<string, string>>
         {
-            new("name1", "value1"),
             new("traceparent", $"00-{TraceId}-{ParentId}-00"),
             new("tracestate", "trace-state"),
         };
 
-        AmazonWebServiceRequest originalRequest = TestsHelper.CreateOriginalRequest(serviceType, 1);
-        var parameters = new ParameterCollection();
-        parameters.AddStringParameters(serviceType, originalRequest);
+        var originalRequest = new SNS.PublishRequest();
 
-        var request = new TestRequest(parameters);
+        var context = new TestRequestContext(originalRequest, new TestRequest());
 
-        var context = new TestRequestContext(originalRequest, request);
+        SnsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
 
-        var addAttributes = TestsHelper.CreateAddAttributesAction(serviceType, context);
-        addAttributes?.Invoke(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
-
-        TestsHelper.AssertStringParameters(serviceType, expectedParameters, parameters);
+        TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
     }
 
-    [Theory]
-    [InlineData(AWSServiceType.SQSService)]
-    [InlineData(AWSServiceType.SNSService)]
-    public void AddAttributes_ParametersCollectionWithTraceParent_TraceStateNotInjected(string serviceType)
+    [Fact]
+    public void SQS_AddAttributes_MessageAttributesWithTraceParent_TraceStateNotInjected()
     {
         // This test just checks the common implementation logic:
         // if at least one attribute is already present the whole injection is skipped.
         // We just use default trace propagator as an example which injects only traceparent and tracestate.
 
-        var expectedParameters = new List<KeyValuePair<string, string>>()
+        var expectedParameters = new List<KeyValuePair<string, string>>
         {
             new("traceparent", $"00-{TraceId}-{ParentId}-00"),
         };
 
-        AmazonWebServiceRequest originalRequest = TestsHelper.CreateOriginalRequest(serviceType, 0);
-        originalRequest.AddAttribute("traceparent", $"00-{TraceId}-{ParentId}-00");
+        var originalRequest = new SQS.SendMessageRequest();
 
-        var parameters = new ParameterCollection();
-        parameters.AddStringParameters(serviceType, originalRequest);
+        var context = new TestRequestContext(originalRequest, new TestRequest());
 
-        var request = new TestRequest(parameters);
-        var context = new TestRequestContext(originalRequest, request);
+        SqsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
 
-        var addAttributes = TestsHelper.CreateAddAttributesAction(serviceType, context);
-        addAttributes?.Invoke(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
+        TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
+    }
 
-        TestsHelper.AssertStringParameters(serviceType, expectedParameters, parameters);
+    [Fact]
+    public void SNS_AddAttributes_MessageAttributesWithTraceParent_TraceStateNotInjected()
+    {
+        // This test just checks the common implementation logic:
+        // if at least one attribute is already present the whole injection is skipped.
+        // We just use default trace propagator as an example which injects only traceparent and tracestate.
+
+        var expectedParameters = new List<KeyValuePair<string, string>>
+        {
+            new("traceparent", $"00-{TraceId}-{ParentId}-00"),
+        };
+
+        var originalRequest = new SNS.PublishRequest();
+
+        var context = new TestRequestContext(originalRequest, new TestRequest());
+
+        SnsRequestContextHelper.AddAttributes(context, AWSMessagingUtils.InjectIntoDictionary(CreatePropagationContext()));
+
+        TestsHelper.AssertMessageParameters(expectedParameters, originalRequest);
     }
 
     private static PropagationContext CreatePropagationContext()

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestAWSClientInstrumentation.cs
@@ -174,6 +174,7 @@ public class TestAWSClientInstrumentation
             var send_msg_req = new SendMessageRequest();
             send_msg_req.QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/MyTestQueue";
             send_msg_req.MessageBody = "Hello from OT";
+            send_msg_req.MessageAttributes.Add("Custom", new MessageAttributeValue { StringValue = "Value", DataType = "String" });
 #if NETFRAMEWORK
             sqs.SendMessage(send_msg_req);
 #else
@@ -198,8 +199,8 @@ public class TestAWSClientInstrumentation
 
     private void ValidateDynamoActivityTags(Activity ddb_activity)
     {
-        Assert.Equal("DynamoDBv2.Scan", ddb_activity.DisplayName);
-        Assert.Equal("DynamoDBv2", Utils.GetTagValue(ddb_activity, "aws.service"));
+        Assert.Equal("DynamoDB.Scan", ddb_activity.DisplayName);
+        Assert.Equal("DynamoDB", Utils.GetTagValue(ddb_activity, "aws.service"));
         Assert.Equal("Scan", Utils.GetTagValue(ddb_activity, "aws.operation"));
         Assert.Equal("us-east-1", Utils.GetTagValue(ddb_activity, "aws.region"));
         Assert.Equal("SampleProduct", Utils.GetTagValue(ddb_activity, "aws.table_name"));

--- a/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
+++ b/test/OpenTelemetry.Instrumentation.AWS.Tests/TestRequest.cs
@@ -13,9 +13,9 @@ using Amazon.Runtime.Internal.Util;
 
 namespace OpenTelemetry.Instrumentation.AWS.Tests;
 
-internal class TestRequest(ParameterCollection parameters) : IRequest
+internal class TestRequest(ParameterCollection parameters = null) : IRequest
 {
-    private readonly ParameterCollection parameters = parameters;
+    private readonly ParameterCollection parameters = parameters ?? new ParameterCollection();
 
     public string RequestName => throw new NotImplementedException();
 


### PR DESCRIPTION
Bug Fix for: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1492.

It looks like SQS changed from an XML Service to a Json Service, which means the `AWSTracingPipelineHandler` can no longer manipulate `SendMessageRequest.MessageAttributes` after the Marshalling step as those changes will not be sent on the wire to SQS which in turn causes SQS and the SDK to calculate different MD5 hashes and throw an exception.

TODO
- [x] Confirm `ServiceId` is the same as `ServiceName`
- [x] Test OTel Baggage propagates correctly.